### PR TITLE
Use the correct block at each step in XceptionFpn

### DIFF
--- a/quantnn/models/pytorch/xception.py
+++ b/quantnn/models/pytorch/xception.py
@@ -133,8 +133,8 @@ class XceptionFpn(nn.Module):
         x_2 = self.down_block_2(x_in)
         x_4 = self.down_block_4(x_2)
         x_8 = self.down_block_8(x_4)
-        x_16 = self.down_block_8(x_8)
-        x_32 = self.down_block_16(x_16)
+        x_16 = self.down_block_16(x_8)
+        x_32 = self.down_block_32(x_16)
 
         x_16_u = self.up_block_16(x_32, x_16)
         x_8_u = self.up_block_8(x_16_u, x_8)


### PR DESCRIPTION
A block was reused while another was not used. Following the logic of the code and variable names, I think this is the expected process.